### PR TITLE
Configure repository for RTD integration.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,35 @@
+name: Synchronize
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      status: $${{ steps.check.outputs.status }}
+    steps:
+      - name: Check that the latest commit is less than 1 day old
+        continue-on-error: true
+        id: check
+        run: >
+          curl -s https://api.github.com/repos/docutils/docutils/commits/master | \
+            jq -e -r "(((now - (.commit.committer.date | fromdateiso8601)) / (60*60*24)) | trunc) < 1"
+          echo "status=$?" >> $GITHUB_OUTPUT
+  synchronize:
+    needs: check
+    runs-on: ubuntu-latest
+    if: ${{ needs.check.outputs.status == 0 }}
+    steps:
+      - name: Update
+        uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: picnixz
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          base: master
+          head: master
+          merge_method: rebase
+          pr_title: Fork Sync
+          auto_approve: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_build:
+      - python -m sphinx.ext.apidoc -f -eMT -P -d1 -t _templates --implicit-namespaces -o docutils/docs docutils/docutils
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docutils/docs/conf.py
+

--- a/docutils/docs/_templates/module.rst_t
+++ b/docutils/docs/_templates/module.rst_t
@@ -1,0 +1,5 @@
+{{- [basename, "module"] | join(" ") | e | heading }}
+
+.. automodule:: {{ qualname }}
+:members:
+{{- "\n" }}

--- a/docutils/docs/_templates/package.rst_t
+++ b/docutils/docs/_templates/package.rst_t
@@ -1,0 +1,25 @@
+{%- macro toctree(docnames) -%}
+.. toctree::
+:maxdepth: {{ maxdepth }}
+{% for docname in docnames %}
+{{ docname }}
+{%- endfor %}
+{%- endmacro -%}
+
+{{- [pkgname, "package"] | join(" ") | e | heading }}
+
+.. automodule:: {{ pkgname }}
+:members:
+{%- if submodules %}
+
+{{ "Modules" | heading(2) }}
+
+{{ toctree(submodules) }}
+{%- endif %}
+{%- if subpackages %}
+
+{{ "Packages" | heading(2) }}
+
+{{ toctree(subpackages) }}
+{%- endif %}
+{{- "\n" }}

--- a/docutils/docs/conf.py
+++ b/docutils/docs/conf.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+
+# -----------------------------------------------------------------------------
+
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.extlinks',
+  'sphinx.ext.napoleon',
+  'sphinx.ext.intersphinx',
+  'sphinx.ext.viewcode'
+]
+
+needs_sphinx = '6.1'
+
+project = 'docutils'
+# pylint: disable-next=C0209
+project_copyright = time.strftime('%Y')
+
+root_doc = 'index'
+source_suffix = '.rst'
+include_patterns = ['*.rst']
+templates_path = ['_templates']
+exclude_patterns = ['_build', *templates_path]
+
+add_module_names = False
+python_use_unqualified_type_names = True
+
+# -----------------------------------------------------------------------------
+# Options for HTML output
+# -----------------------------------------------------------------------------
+
+html_static_path = ['_static']
+html_last_updated_fmt = '%b %d, %Y'
+html_split_index = True
+html_search_language = 'en'
+html_domain_indices = True
+html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'display_version': True,
+    'style_external_links': False,
+    'navigation_depth': -1,
+    'includehidden': False
+}
+
+# -----------------------------------------------------------------------------
+# Built-in Sphinx options
+# -----------------------------------------------------------------------------
+
+nitpick_ignore_regex = [
+    (r'py:.*', r'builtins\..*'),
+]
+suppress_warnings = ['toc']
+
+# -----------------------------------------------------------------------------
+# Options for sphinx.ext.autodoc
+# -----------------------------------------------------------------------------
+
+autodoc_default_options = {
+    'ignore-module-all': True,  # force 'bysource' sorting
+    'show-inheritance': True,
+    'private-members': True,
+    'special-members': False,  # handled by Napoleon
+    'inherited-members': False,
+    'undoc-public-members': True
+}
+autodoc_member_order = 'bysource'
+autodoc_typehints = 'both'
+autodoc_typehints_description_target = 'documented'
+
+# -----------------------------------------------------------------------------
+# Options for sphinx.ext.autosummary
+# -----------------------------------------------------------------------------
+
+autosummary_generate = False
+
+# -----------------------------------------------------------------------------
+# Options for sphinx.ext.extlinks
+# -----------------------------------------------------------------------------
+
+extlinks_detect_hardcoded_links = True
+DOCUTILS_URL = 'https://docutils.sourceforge.io/docs/ref'
+extlinks = {
+    'dudtd': (f'{DOCUTILS_URL}/doctree.html#%s', '%s'),
+    'duref': (f'{DOCUTILS_URL}/rst/restructuredtext.html#%s', '%s'),
+    'durole': (f'{DOCUTILS_URL}/rst/roles.html#%s', '%s'),
+    'dudir': (f'{DOCUTILS_URL}/rst/directives.html#%s', '%s')
+}
+
+# -----------------------------------------------------------------------------
+# Options for sphinx.ext.intersphinx
+# -----------------------------------------------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None)
+}
+
+# -----------------------------------------------------------------------------
+# Options for sphinx.ext.napoleon
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# This extension is used for parsing inner sections and include documented
+# members independently of whether they are public, private or special.
+# -----------------------------------------------------------------------------
+
+napoleon_include_init_with_doc = True
+napoleon_include_private_with_doc = True
+napoleon_include_special_with_doc = True

--- a/docutils/docs/index.rst
+++ b/docutils/docs/index.rst
@@ -1,0 +1,28 @@
+docutils
+========
+
+This is a Sphinx auto-generated documentation of :mod:`docutils` for :mod:`!sphinx.ext.intersphinx` usage.
+
+Ussage::
+
+   # conf.py
+   intersphinx_mapping = {
+       'docutils': ('https://sphinx-docutils.readthedocs.io/en/latest/', None)
+   }
+
+This allows developers to cross-reference ``docutils.*`` objects using the :mod:`!sphinx.ext.intersphinx` extension.
+
+.. important::
+
+   The documentation is automatically generated using a `fork <https://github.com/picnixz/docutils>`_ of `docutils <https://github.com/docutils/docutils>`_, the latter being a mirror of `docutils <https://sourceforge.net/p/docutils/code/HEAD/tree/trunk>`_.
+
+   The project is automatically rebuilt using Github workflow actions when the upstream repository is updated. In particular,
+   the documentation being served is always for the latest version of `docutils <https://github.com/docutils/docutils>`_.
+
+.. toctree::
+   :maxdepth: 1
+
+   docutils.rst
+   genindex
+   glossary
+   search


### PR DESCRIPTION
- Configure workflow to trigger automatically when [docutils/docutils](https://github.com/docutils/docutils) is updated.
- Automatic generation of autodoc-related documentation (directly stored on RTD servers).